### PR TITLE
Add axum-prometheus to expose metrics

### DIFF
--- a/src/alarmservice-rs/Cargo.toml
+++ b/src/alarmservice-rs/Cargo.toml
@@ -40,3 +40,8 @@ models = { path = "../models-rs" }
 
 # add chrono for easier timezone handling
 chrono = "0.4.38"
+
+# add 'axum-prometheus' to collect HTTP and custom metrics
+axum-prometheus = { version = "0.7", features = [
+    "metrics-exporter-prometheus",
+] }

--- a/src/alarmservice-rs/src/api/handlers/event_handler.rs
+++ b/src/alarmservice-rs/src/api/handlers/event_handler.rs
@@ -24,6 +24,9 @@ pub async fn new_event_handler(
         .await?
         .ok_or_else(|| CustomError::NotFound)?;
 
+    // update events_counter
+    state.metrics.events_counter.increment(1);
+
     // parse timestamp (and possibly fail) or use Utc::now()
     let event_ts_actual = event_dto.clone().timestamp.map_or_else(
         || Ok::<DateTime<Utc>, CustomError>(Utc::now()), // sorry, if you didn't provide a timestamp, i'm going to use my own time here!

--- a/src/alarmservice-rs/src/api/handlers/rooms_handler.rs
+++ b/src/alarmservice-rs/src/api/handlers/rooms_handler.rs
@@ -41,5 +41,5 @@ pub async fn active_alarm_count_handler(
 
 #[derive(Serialize, Deserialize)]
 pub struct AlarmCountDto {
-    pub active_alarm_count: i32,
+    pub active_alarm_count: i64,
 }

--- a/src/alarmservice-rs/src/api/router.rs
+++ b/src/alarmservice-rs/src/api/router.rs
@@ -3,17 +3,27 @@ use axum::{
     Router,
 };
 
+use axum_prometheus::{metrics_exporter_prometheus::PrometheusHandle, PrometheusMetricLayer};
 use sea_orm::DatabaseConnection;
 
-use super::handlers::{alarms_handler::{acknowledge_alarm_handler, get_alarms_for_room_handler}, event_handler::new_event_handler, hello_handler::hello_handler as get_hello_handler, rooms_handler::{active_alarm_count_handler, get_rooms_handler}, schedule_handler::{get_schedules_handler, post_schedule_handler}};
+use crate::metrics::AppMetrics;
+
+use super::handlers::{
+    alarms_handler::{acknowledge_alarm_handler, get_alarms_for_room_handler},
+    event_handler::new_event_handler,
+    hello_handler::hello_handler as get_hello_handler,
+    rooms_handler::{active_alarm_count_handler, get_rooms_handler},
+    schedule_handler::{get_schedules_handler, post_schedule_handler},
+};
 
 #[derive(Clone)]
 pub struct AppState {
     pub conn: DatabaseConnection,
+    pub metrics: AppMetrics,
 }
 
 // Router definition
-pub fn router(state: AppState) -> Router {
+pub fn router(state: AppState, metric_handle: PrometheusHandle) -> Router {
     // routes which should be always publicly accessible
     let routes: Router = Router::new()
         .route("/hello", get(get_hello_handler))
@@ -22,14 +32,14 @@ pub fn router(state: AppState) -> Router {
         .route("/alarm/:id/acknowledge", post(acknowledge_alarm_handler))
         .route("/alarm", get(get_alarms_for_room_handler))
         .route("/event", post(new_event_handler))
-
-        .with_state(state.clone());
+        .route("/metrics", get(|| async move { metric_handle.render() }))
+        .with_state(state.clone())
+        .layer(PrometheusMetricLayer::new());
 
     let schedules_router = schedules_router(state.clone());
 
     // merge all routes and return
-    routes
-        .merge(schedules_router)
+    routes.merge(schedules_router)
 }
 
 fn schedules_router(state: AppState) -> Router {

--- a/src/alarmservice-rs/src/metrics.rs
+++ b/src/alarmservice-rs/src/metrics.rs
@@ -1,0 +1,16 @@
+use axum_prometheus::metrics::{counter, Counter};
+
+#[derive(Clone)]
+pub struct AppMetrics {
+    pub events_counter: Counter,
+}
+
+impl AppMetrics {
+    pub fn init() -> Self {
+        // initialize metrics
+        let events_counter = counter!("events_counter");
+
+        // initialize AppMetrics
+        Self { events_counter }
+    }
+}

--- a/src/alarmservice-rs/src/persistence/repositories/alarm_repo.rs
+++ b/src/alarmservice-rs/src/persistence/repositories/alarm_repo.rs
@@ -23,5 +23,5 @@ fn prepare_count_active_alarms(room_id: i64) -> Selector<SelectModel<AlarmCount>
 
 #[derive(Clone, Debug, FromQueryResult)]
 pub struct AlarmCount {
-    pub active_alarm_count: i32,
+    pub active_alarm_count: i64,
 }


### PR DESCRIPTION
this is how the response from `/metrics` looks like:

```
# TYPE events_counter counter
events_counter{app="alertservice-rs"} 2

# TYPE axum_http_requests_total counter
axum_http_requests_total{app="alertservice-rs",method="POST",status="201",endpoint="/event"} 2
axum_http_requests_total{app="alertservice-rs",method="GET",status="200",endpoint="/metrics"} 1

# TYPE axum_http_requests_pending gauge
axum_http_requests_pending{app="alertservice-rs",method="POST",endpoint="/event"} 0
axum_http_requests_pending{app="alertservice-rs",method="GET",endpoint="/metrics"} 1

# TYPE axum_http_requests_duration_seconds summary
axum_http_requests_duration_seconds{app="alertservice-rs",method="POST",status="201",endpoint="/event",quantile="0"} 0.021257
axum_http_requests_duration_seconds{app="alertservice-rs",method="POST",status="201",endpoint="/event",quantile="0.5"} 0.021256341218666874
axum_http_requests_duration_seconds{app="alertservice-rs",method="POST",status="201",endpoint="/event",quantile="0.9"} 0.021256341218666874
axum_http_requests_duration_seconds{app="alertservice-rs",method="POST",status="201",endpoint="/event",quantile="0.95"} 0.021256341218666874
axum_http_requests_duration_seconds{app="alertservice-rs",method="POST",status="201",endpoint="/event",quantile="0.99"} 0.021256341218666874
axum_http_requests_duration_seconds{app="alertservice-rs",method="POST",status="201",endpoint="/event",quantile="0.999"} 0.021256341218666874
axum_http_requests_duration_seconds{app="alertservice-rs",method="POST",status="201",endpoint="/event",quantile="1"} 0.098642875
axum_http_requests_duration_seconds_sum{app="alertservice-rs",method="POST",status="201",endpoint="/event"} 0.119899875
axum_http_requests_duration_seconds_count{app="alertservice-rs",method="POST",status="201",endpoint="/event"} 2
axum_http_requests_duration_seconds{app="alertservice-rs",method="GET",status="200",endpoint="/metrics",quantile="0"} 0.000645292
axum_http_requests_duration_seconds{app="alertservice-rs",method="GET",status="200",endpoint="/metrics",quantile="0.5"} 0.0006452323783851901
axum_http_requests_duration_seconds{app="alertservice-rs",method="GET",status="200",endpoint="/metrics",quantile="0.9"} 0.0006452323783851901
axum_http_requests_duration_seconds{app="alertservice-rs",method="GET",status="200",endpoint="/metrics",quantile="0.95"} 0.0006452323783851901
axum_http_requests_duration_seconds{app="alertservice-rs",method="GET",status="200",endpoint="/metrics",quantile="0.99"} 0.0006452323783851901
axum_http_requests_duration_seconds{app="alertservice-rs",method="GET",status="200",endpoint="/metrics",quantile="0.999"} 0.0006452323783851901
axum_http_requests_duration_seconds{app="alertservice-rs",method="GET",status="200",endpoint="/metrics",quantile="1"} 0.000645292
axum_http_requests_duration_seconds_sum{app="alertservice-rs",method="GET",status="200",endpoint="/metrics"} 0.000645292
axum_http_requests_duration_seconds_count{app="alertservice-rs",method="GET",status="200",endpoint="/metrics"} 1


```